### PR TITLE
Create schema bundle and deprecate playbook and tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,7 @@
     "./f/ansible-galaxy.json": ["examples/**/galaxy.yml"],
     "./f/ansible-lint.json": [".ansible-lint", ".config/ansiblelint.yml"],
     "./f/ansible-meta.json": ["meta/main.yml"],
-    "./f/ansible-playbook.json": ["playbooks/*.yml", "playbooks/*.yaml"],
     "./f/ansible-requirements.json": ["requirements.yml"],
-    "./f/ansible-tasks.json": ["tasks/*.yml", "handlers/*.yml"],
     "./f/ansible-vars.json": [
       "playbooks/vars/*.yml",
       "vars/*.yml",
@@ -17,6 +15,11 @@
       "host_vars/*.yml",
       "group_vars/*.yml"
     ],
+    "./f/ansible.json#/definitions/playbook": [
+      "playbooks/*.yml",
+      "playbooks/*.yaml"
+    ],
+    "./f/ansible.json#/definitions/tasks": ["tasks/*.yml", "handlers/*.yml"],
     "./f/molecule.json": ["molecule.yml"],
     "./f/zuul.json": ["zuul.d/**/*.yml", "zuul.d/**/*.yaml"]
   }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ expect them to take a longer time until someone finds time to fix them.
 If you want to help improve the schemas, have a look at the
 [development documentation](CONTRIBUTING.md).
 
+## Schema Bundle
+
+We are currently migrating towards a single [ansible.json](/f/ansible.json)
+schema bundle, one that contains subschema definitions for all the supported
+file types.
+
+To configure your validator or editor to use the bundle, use the new URLs below,
+the part after the `#` in the URLs is essential for informing the loader about
+which subschema to use. You can also look at our own
+[settings.json](.vscode/settings.json) to understand how to configure
+[vscode-yaml](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+extension.
+
+- [playbook subschema url](https://raw.githubusercontent.com/ansible/schemas/main/f/ansible.json#/definitions/playbook)
+- [tasks subschema uri](https://raw.githubusercontent.com/ansible/schemas/main/f/ansible.json#/definitions/tasks)
+
 ## Activating the schemas
 
 At this moment installing

--- a/f/ansible-tasks.json
+++ b/f/ansible-tasks.json
@@ -463,6 +463,7 @@
       "type": "string"
     }
   },
+  "deprecated": true,
   "examples": ["tasks/*.yml", "handlers/*.yml"],
   "items": {
     "anyOf": [
@@ -474,6 +475,6 @@
       }
     ]
   },
-  "title": "Ansible Tasks Schema",
+  "title": "DEPRECATED: Read https://github.com/ansible/schemas#schema-bundle",
   "type": "array"
 }

--- a/f/ansible.json
+++ b/f/ansible.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-playbook.json",
+  "$id": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "additionalProperties": false,
   "definitions": {
@@ -603,6 +603,21 @@
       "title": "play-role",
       "type": "object"
     },
+    "playbook": {
+      "examples": ["playbooks/*.yml", "playbooks/*.yaml"],
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/ansible.builtin.import_playbook"
+          },
+          {
+            "$ref": "#/definitions/play"
+          }
+        ]
+      },
+      "title": "Ansible Playbook",
+      "type": "array"
+    },
     "task": {
       "additionalProperties": true,
       "not": {
@@ -947,7 +962,6 @@
       "type": "object"
     }
   },
-  "deprecated": true,
   "examples": ["playbooks/*.yml", "playbooks/*.yaml"],
   "items": {
     "anyOf": [
@@ -959,6 +973,6 @@
       }
     ]
   },
-  "title": "DEPRECATED: Read https://github.com/ansible/schemas#schema-bundle",
+  "title": "Ansible Schemas Bundle 22.4",
   "type": "array"
 }


### PR DESCRIPTION
This change does not remove the deprecated schemas as we want to give others time to change the urls.

This change is effectively copying the `ansible-playbook.json` to `ansible.json` and adds deprecation messages to old schemas.

It should be noted that our test suite is now testing both new and old schemas as they were
designed to validate and test all schemas from that folder.

Partial-Fix: #207