### PR TITLE
Add more example locations for ansible-lint config files

### DIFF
--- a/f/ansible-lint.json
+++ b/f/ansible-lint.json
@@ -2,7 +2,14 @@
   "$id": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-lint.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "additionalProperties": false,
-  "examples": [".ansible-lint", ".config/ansiblelint.yml"],
+  "examples": [
+    ".ansible-lint",
+    ".ansible-lint.yml",
+    ".ansible-lint.yaml",
+    ".config/ansible-lint",
+    ".config/ansible-lint.yml",
+    ".config/ansible-lint.yaml"
+  ],
   "properties": {
     "enable_list": {
       "items": {


### PR DESCRIPTION
Merge this after https://github.com/ansible/ansible-lint/pull/2072 is merged.

Also contains a fix for a typo (`.config/ansiblelint.yml` probably should have been `.config/ansible-lint.yml`)