### PR TITLE
tags can be either string or list of strings

### DIFF
--- a/f/ansible-playbook.json
+++ b/f/ansible-playbook.json
@@ -566,11 +566,18 @@
           "type": "boolean"
         },
         "tags": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Tags",
-          "type": "array"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Tags"
         },
         "throttle": {
           "title": "Throttle",

--- a/f/ansible.json
+++ b/f/ansible.json
@@ -588,11 +588,18 @@
           "type": "boolean"
         },
         "tags": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Tags",
-          "type": "array"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Tags"
         },
         "throttle": {
           "title": "Throttle",

--- a/test/playbooks/roles.yml
+++ b/test/playbooks/roles.yml
@@ -9,3 +9,5 @@
         FOO: bar
       tags:
         - foo
+    - role: bar
+      tags: string_tag

--- a/test/playbooks/tasks/tags.yml
+++ b/test/playbooks/tasks/tags.yml
@@ -1,0 +1,29 @@
+- command: echo 123
+  tags:
+    - foo
+    - bar
+
+- command: echo 123
+  tags: foo
+
+- block:
+    - command: echo 123
+      tags:
+        - foo
+        - bar
+
+    - command: echo 123
+      tags: foo
+  tags:
+    - foo
+    - bar
+
+- block:
+    - command: echo 123
+      tags:
+        - foo
+        - bar
+
+    - command: echo 123
+      tags: foo
+  tags: foo


### PR DESCRIPTION
I suspect this was an oversight?

There are also "array-only" `tags` definitions in ansible-meta, ansible-lint and ansible-galaxy. These might also be "string OR array-of-strings" type, but I didn't check or verify those.