### PR TITLE
Dump errors to markdown

### DIFF
--- a/negative_test/molecule/platforms_children/molecule.yml.md
+++ b/negative_test/molecule/platforms_children/molecule.yml.md
@@ -1,0 +1,15 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "/platforms/0/children",
+    "keyword": "type",
+    "message": "must be array",
+    "params": {
+      "type": "array"
+    },
+    "schemaPath": "#/properties/children/type"
+  }
+]
+```

--- a/negative_test/molecule/platforms_networks/molecule.yml.md
+++ b/negative_test/molecule/platforms_networks/molecule.yml.md
@@ -1,0 +1,24 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "/platforms/0/networks/0",
+    "keyword": "type",
+    "message": "must be object",
+    "params": {
+      "type": "object"
+    },
+    "schemaPath": "#/definitions/platform-network/type"
+  },
+  {
+    "instancePath": "/platforms/0/networks/1",
+    "keyword": "type",
+    "message": "must be object",
+    "params": {
+      "type": "object"
+    },
+    "schemaPath": "#/definitions/platform-network/type"
+  }
+]
+```

--- a/negative_test/playbooks/vars/asterisk.yml.md
+++ b/negative_test/playbooks/vars/asterisk.yml.md
@@ -1,0 +1,40 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "additionalProperties",
+    "message": "must NOT have additional properties",
+    "params": {
+      "additionalProperty": "*foo"
+    },
+    "schemaPath": "#/anyOf/0/additionalProperties"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be string",
+    "params": {
+      "type": "string"
+    },
+    "schemaPath": "#/anyOf/1/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/2/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/playbooks/vars/dash-in-var-name.yml.md
+++ b/negative_test/playbooks/vars/dash-in-var-name.yml.md
@@ -1,0 +1,40 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "additionalProperties",
+    "message": "must NOT have additional properties",
+    "params": {
+      "additionalProperty": "foo-bar"
+    },
+    "schemaPath": "#/anyOf/0/additionalProperties"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be string",
+    "params": {
+      "type": "string"
+    },
+    "schemaPath": "#/anyOf/1/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/2/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/playbooks/vars/list.yml.md
+++ b/negative_test/playbooks/vars/list.yml.md
@@ -1,0 +1,40 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be object",
+    "params": {
+      "type": "object"
+    },
+    "schemaPath": "#/anyOf/0/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be string",
+    "params": {
+      "type": "string"
+    },
+    "schemaPath": "#/anyOf/1/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/2/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/playbooks/vars/numeric-var-name.yml.md
+++ b/negative_test/playbooks/vars/numeric-var-name.yml.md
@@ -1,0 +1,40 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "additionalProperties",
+    "message": "must NOT have additional properties",
+    "params": {
+      "additionalProperty": "12"
+    },
+    "schemaPath": "#/anyOf/0/additionalProperties"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be string",
+    "params": {
+      "type": "string"
+    },
+    "schemaPath": "#/anyOf/1/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/2/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/playbooks/vars/play-keyword.yml.md
+++ b/negative_test/playbooks/vars/play-keyword.yml.md
@@ -1,0 +1,40 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "additionalProperties",
+    "message": "must NOT have additional properties",
+    "params": {
+      "additionalProperty": "environment"
+    },
+    "schemaPath": "#/anyOf/0/additionalProperties"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be string",
+    "params": {
+      "type": "string"
+    },
+    "schemaPath": "#/anyOf/1/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/2/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/playbooks/vars/python-keyword.yml.md
+++ b/negative_test/playbooks/vars/python-keyword.yml.md
@@ -1,0 +1,49 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "additionalProperties",
+    "message": "must NOT have additional properties",
+    "params": {
+      "additionalProperty": "async"
+    },
+    "schemaPath": "#/anyOf/0/additionalProperties"
+  },
+  {
+    "instancePath": "",
+    "keyword": "additionalProperties",
+    "message": "must NOT have additional properties",
+    "params": {
+      "additionalProperty": "lambda"
+    },
+    "schemaPath": "#/anyOf/0/additionalProperties"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be string",
+    "params": {
+      "type": "string"
+    },
+    "schemaPath": "#/anyOf/1/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/2/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/playbooks/vars/varname-numeric-prefix.yml.md
+++ b/negative_test/playbooks/vars/varname-numeric-prefix.yml.md
@@ -1,0 +1,40 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "additionalProperties",
+    "message": "must NOT have additional properties",
+    "params": {
+      "additionalProperty": "5foo"
+    },
+    "schemaPath": "#/anyOf/0/additionalProperties"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be string",
+    "params": {
+      "type": "string"
+    },
+    "schemaPath": "#/anyOf/1/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/2/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/reqs3/meta/requirements.yml.md
+++ b/negative_test/reqs3/meta/requirements.yml.md
@@ -1,0 +1,56 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be array",
+    "params": {
+      "type": "array"
+    },
+    "schemaPath": "#/anyOf/0/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "required",
+    "message": "must have required property 'collections'",
+    "params": {
+      "missingProperty": "collections"
+    },
+    "schemaPath": "#/anyOf/0/required"
+  },
+  {
+    "instancePath": "",
+    "keyword": "required",
+    "message": "must have required property 'roles'",
+    "params": {
+      "missingProperty": "roles"
+    },
+    "schemaPath": "#/anyOf/1/required"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  },
+  {
+    "instancePath": "",
+    "keyword": "additionalProperties",
+    "message": "must NOT have additional properties",
+    "params": {
+      "additionalProperty": "foo"
+    },
+    "schemaPath": "#/additionalProperties"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/roles/meta/main.yml.md
+++ b/negative_test/roles/meta/main.yml.md
@@ -1,0 +1,31 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/0/type"
+  },
+  {
+    "instancePath": "/galaxy_info/galaxy_tags",
+    "keyword": "type",
+    "message": "must be array",
+    "params": {
+      "type": "array"
+    },
+    "schemaPath": "#/properties/galaxy_tags/type"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/roles/meta_invalid_collection/meta/main.yml.md
+++ b/negative_test/roles/meta_invalid_collection/meta/main.yml.md
@@ -1,0 +1,31 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/0/type"
+  },
+  {
+    "instancePath": "/collections/0",
+    "keyword": "pattern",
+    "message": "must match pattern \"^[a-z_]+\\.[a-z_]+$\"",
+    "params": {
+      "pattern": "^[a-z_]+\\.[a-z_]+$"
+    },
+    "schemaPath": "#/anyOf/1/properties/collections/items/pattern"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/roles/meta_invalid_collections/meta/main.yml.md
+++ b/negative_test/roles/meta_invalid_collections/meta/main.yml.md
@@ -1,0 +1,31 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/0/type"
+  },
+  {
+    "instancePath": "/collections/0",
+    "keyword": "pattern",
+    "message": "must match pattern \"^[a-z_]+\\.[a-z_]+$\"",
+    "params": {
+      "pattern": "^[a-z_]+\\.[a-z_]+$"
+    },
+    "schemaPath": "#/anyOf/1/properties/collections/items/pattern"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml.md
+++ b/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml.md
@@ -1,0 +1,56 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/0/type"
+  },
+  {
+    "instancePath": "/dependencies/0",
+    "keyword": "required",
+    "message": "must have required property 'role'",
+    "params": {
+      "missingProperty": "role"
+    },
+    "schemaPath": "#/definitions/DependencyModel/anyOf/0/required"
+  },
+  {
+    "instancePath": "/dependencies/0",
+    "keyword": "required",
+    "message": "must have required property 'src'",
+    "params": {
+      "missingProperty": "src"
+    },
+    "schemaPath": "#/definitions/DependencyModel/anyOf/1/required"
+  },
+  {
+    "instancePath": "/dependencies/0",
+    "keyword": "required",
+    "message": "must have required property 'name'",
+    "params": {
+      "missingProperty": "name"
+    },
+    "schemaPath": "#/definitions/DependencyModel/anyOf/2/required"
+  },
+  {
+    "instancePath": "/dependencies/0",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/definitions/DependencyModel/anyOf"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "ajv-cli": "^5.0.0",
         "ajv-formats": "^2.1.1",
         "js-yaml": "^4.1.0",
+        "safe-stable-stringify": "^2.3.1",
         "ts-node": "^10.5.0",
         "vscode-json-languageservice": "^4.2.0"
       },
@@ -1120,6 +1121,14 @@
         }
       ]
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -2231,6 +2240,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
+    },
+    "safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
     },
     "serialize-javascript": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "ajv-cli": "^5.0.0",
     "ajv-formats": "^2.1.1",
     "js-yaml": "^4.1.0",
+    "safe-stable-stringify": "^2.3.1",
     "ts-node": "^10.5.0",
     "vscode-json-languageservice": "^4.2.0"
   },

--- a/src/schema.spec.ts
+++ b/src/schema.spec.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import minimatch from "minimatch";
 import yaml from "js-yaml";
 import { assert } from "chai";
+import stringify from "safe-stable-stringify";
 
 const ajv = new Ajv({
   strictTypes: false,
@@ -42,9 +43,19 @@ describe("schemas under f/", function () {
       getTestFiles(schema_json.examples).forEach(
         ({ file: test_file, expect_fail }) => {
           it(`linting ${test_file} using ${schema_file}`, function () {
+            var errors_md = "";
             const result = validator(
               yaml.load(fs.readFileSync(test_file, "utf8"))
             );
+            if (validator.errors) {
+              errors_md += "# ajv errors\n\n```json\n";
+              errors_md += stringify(validator.errors, null, 2);
+              errors_md += "\n```\n";
+            }
+            // dump errors to markdown file for manual inspection
+            if (errors_md) {
+              fs.writeFileSync(`${test_file}.md`, errors_md);
+            }
             assert.equal(
               result,
               !expect_fail,


### PR DESCRIPTION
This should allow us to evaluate how error messages are changed
when we modify the schema.

We will also include errors generated by other validators, as their
messaging can be very different.
