### PR TITLE
vars: correct keyword detection regex

### DIFF
--- a/f/ansible-vars.json
+++ b/f/ansible-vars.json
@@ -5,7 +5,7 @@
     {
       "additionalProperties": false,
       "patternProperties": {
-        "^(?!False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)[a-zA-Z_][\\w]*$": {}
+        "^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\w]*$": {}
       },
       "type": "object"
     },

--- a/src/update-schemas.py
+++ b/src/update-schemas.py
@@ -53,7 +53,7 @@ print("Updating invalid var names")
 with open("f/ansible-vars.json", "r+", encoding="utf-8") as f:
     vars_schema = json.load(f)
     vars_schema['anyOf'][0]['patternProperties'] = {
-        f"^(?!{'|'.join(invalid_var_names)})[a-zA-Z_][\\w]*$": {}
+        f"^(?!({'|'.join(invalid_var_names)})$)[a-zA-Z_][\\w]*$": {}
     }
     f.seek(0)
     json.dump(vars_schema, f, indent=2)

--- a/test/playbooks/defaults/foo.yml
+++ b/test/playbooks/defaults/foo.yml
@@ -1,0 +1,3 @@
+# defaults have same format as vars
+in_is_reserved: ...
+ss: ss

--- a/test/playbooks/vars/myvars.yml
+++ b/test/playbooks/vars/myvars.yml
@@ -1,5 +1,9 @@
 foo: bar
 _foo: bar
+foo_var_xxx: "{{ sss }}"
+in_job: ...
 nested:
   pear: fruit
   apple: fruit
+sso_force_handlers: ...
+force_handlers_foo: ...


### PR DESCRIPTION
Fixed bug where a variable name like `intercept` would not be allowed because it was starting with a `in`, which is a keyword.