### PR TITLE
Improve inventory schema

### DIFF
--- a/f/ansible-inventory.json
+++ b/f/ansible-inventory.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-inventory.json",
   "$schema": "http://json-schema.org/draft-07/schema",
+  "additionalProperties": false,
   "definitions": {
     "group": {
       "properties": {
@@ -23,13 +24,21 @@
           "type": "object"
         }
       },
-      "type": "object"
+      "type": ["object", "null"]
     }
   },
   "description": "Ansible Inventory Schema",
-  "examples": ["inventory.yaml", "inventory.yml"],
+  "examples": [
+    "inventory.yaml",
+    "inventory.yml",
+    "inventory/*.yml",
+    "inventory/*.yaml"
+  ],
   "properties": {
     "all": {
+      "$ref": "#/definitions/group"
+    },
+    "ungrouped": {
       "$ref": "#/definitions/group"
     }
   },

--- a/f/ansible-inventory.json
+++ b/f/ansible-inventory.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-inventory.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "definitions": {
     "group": {
       "properties": {
@@ -25,6 +25,24 @@
         }
       },
       "type": ["object", "null"]
+    },
+    "special-group": {
+      "additionalProperties": false,
+      "properties": {
+        "children": {
+          "type": ["object", "null"]
+        },
+        "groups": {
+          "type": ["object", "null"]
+        },
+        "hosts": {
+          "type": ["object", "null"]
+        },
+        "vars": {
+          "type": ["object", "null"]
+        }
+      },
+      "type": "object"
     }
   },
   "description": "Ansible Inventory Schema",
@@ -34,9 +52,10 @@
     "inventory/*.yml",
     "inventory/*.yaml"
   ],
+  "markdownDescription": "All keys at top levels are groups with `all` and `ungrouped` having a special meaning.\n\nSee [How to build your inventory](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html)",
   "properties": {
     "all": {
-      "$ref": "#/definitions/group"
+      "$ref": "#/definitions/special-group"
     },
     "ungrouped": {
       "$ref": "#/definitions/group"

--- a/negative_test/inventory/broken_dev_inventory.yml
+++ b/negative_test/inventory/broken_dev_inventory.yml
@@ -1,0 +1,2 @@
+all:
+  foo: {} # invalid based on inventory json schema

--- a/negative_test/inventory/broken_dev_inventory.yml
+++ b/negative_test/inventory/broken_dev_inventory.yml
@@ -1,2 +1,10 @@
+---
+# See https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
+ungrouped: {}
 all:
-  foo: {} # invalid based on inventory json schema
+  hosts:
+    mail.example.com:
+  children:
+  foo: {} # <-- invalid based on inventory json schema
+  vars: {}
+webservers: {}

--- a/negative_test/inventory/broken_dev_inventory.yml.md
+++ b/negative_test/inventory/broken_dev_inventory.yml.md
@@ -1,0 +1,29 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "/all",
+    "keyword": "additionalProperties",
+    "message": "must NOT have additional properties",
+    "params": {
+      "additionalProperty": "foo"
+    },
+    "schemaPath": "#/definitions/special-group/additionalProperties"
+  }
+]
+```
+
+# check-jsonschema
+
+stderr:
+
+```
+Schema validation errors were encountered.
+```
+
+stdout:
+
+```
+  negative_test/inventory/broken_dev_inventory.yml::$.all: Additional properties are not allowed ('foo' was unexpected)
+```

--- a/test/inventory/inventory.yml
+++ b/test/inventory/inventory.yml
@@ -1,0 +1,31 @@
+---
+# https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
+ungrouped: {}
+all:
+  hosts:
+    mail.example.com:
+  children:
+    webservers:
+      hosts:
+        foo.example.com:
+        bar.example.com:
+    dbservers:
+      hosts:
+        one.example.com:
+        two.example.com:
+        three.example.com:
+    east:
+      hosts:
+        foo.example.com:
+        one.example.com:
+        two.example.com:
+    west:
+      hosts:
+        bar.example.com:
+        three.example.com:
+    prod:
+      children:
+        east: {}
+    test:
+      children:
+        west: {}

--- a/test/inventory/production.yml
+++ b/test/inventory/production.yml
@@ -1,0 +1,37 @@
+all:
+  hosts:
+    mail.example.com:
+  children:
+    webservers:
+      hosts:
+        foo.example.com:
+        bar.example.com:
+        # ranges are supported:
+        www[01:50].example.com:
+        www[01:50:2].example.com:
+          # these are variables:
+          var_1: value_1
+          another_var: 200
+    dbservers:
+      hosts:
+        one.example.com:
+        two.example.com:
+        three.example.com:
+    east:
+      hosts:
+        foo.example.com:
+        one.example.com:
+        two.example.com:
+    west:
+      hosts:
+        bar.example.com:
+        three.example.com:
+    prod:
+      children:
+        east:
+    test:
+      children:
+        west:
+  # add variables for all hosts
+  vars:
+    my_var: 123


### PR DESCRIPTION
As even official Ansible documentation makes use of lots of
`hostname: null` examples, we ensure that we allow these.
