### PR TITLE
Fix argspec schema: support version_added, and lists of strings for author and description

### DIFF
--- a/f/ansible-argument-specs.json
+++ b/f/ansible-argument-specs.json
@@ -39,10 +39,26 @@
       "additionalProperties": false,
       "properties": {
         "author": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+              "items": "string"
+            }
+          ]
         },
         "description": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+              "items": "string"
+            }
+          ]
         },
         "options": {
           "additionalProperties": {
@@ -51,6 +67,9 @@
           "type": "object"
         },
         "short_description": {
+          "type": "string"
+        },
+        "version_added": {
           "type": "string"
         }
       },
@@ -88,7 +107,15 @@
         },
         "description": {
           "description": "Detailed explanation of what this option does. It should be written in full sentences.",
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+              "items": "string"
+            }
+          ]
         },
         "elements": {
           "$ref": "#/$defs/datatype"
@@ -112,6 +139,9 @@
         "type": {
           "$ref": "#/$defs/datatype",
           "markdownDescription": "See [argument-spec](https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec"
+        },
+        "version_added": {
+          "type": "string"
         }
       },
       "removed_at_date": {


### PR DESCRIPTION
The current argspec schema has some bugs:
1. It doens't support `version_added`;
2. It doesn't allow list of strings for `author` and `description`.