### PR TITLE
argspec: support seealso, sub-options, and fix choices

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -57,6 +57,7 @@ rulesdir
 runas
 schemafile
 scrapy
+seealso
 setuptools
 ssbarnea
 subdir

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -9,7 +9,6 @@ dictionaries:
   - bash
   - words
   - python
-  - seealso
 ignorePaths:
   - cspell.config.yaml
   - .gitignore

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -9,6 +9,7 @@ dictionaries:
   - bash
   - words
   - python
+  - seealso
 ignorePaths:
   - cspell.config.yaml
   - .gitignore

--- a/f/ansible-argument-specs.json
+++ b/f/ansible-argument-specs.json
@@ -73,6 +73,71 @@
         "short_description": {
           "type": "string"
         },
+        "seealso": {
+          "items": {
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "module": {
+                    "type": "string"
+                  }
+                },
+                "required": ["module"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "plugin": {
+                    "type": "string"
+                  },
+                  "plugin_type": {
+                    "type": "string"
+                  }
+                },
+                "required": ["plugin", "plugin_type"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "ref": {
+                    "type": "string"
+                  }
+                },
+                "required": ["description", "ref"],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "link": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": ["description", "link", "name"],
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        },
         "version_added": {
           "type": "string"
         }
@@ -104,7 +169,7 @@
       },
       "properties": {
         "choices": {
-          "$ref": "#/$defs/datatype"
+          "type": "array"
         },
         "default": {
           "default": "None"
@@ -133,6 +198,12 @@
         "no_log": {
           "default": false,
           "type": "boolean"
+        },
+        "options": {
+          "additionalProperties": {
+            "$ref": "#/$defs/option"
+          },
+          "type": "object"
         },
         "option-name": {
           "description": "The name of the option/argument.",

--- a/f/ansible-argument-specs.json
+++ b/f/ansible-argument-specs.json
@@ -70,9 +70,6 @@
           },
           "type": "object"
         },
-        "short_description": {
-          "type": "string"
-        },
         "seealso": {
           "items": {
             "oneOf": [
@@ -138,6 +135,9 @@
           },
           "type": "array"
         },
+        "short_description": {
+          "type": "string"
+        },
         "version_added": {
           "type": "string"
         }
@@ -199,15 +199,15 @@
           "default": false,
           "type": "boolean"
         },
+        "option-name": {
+          "description": "The name of the option/argument.",
+          "type": "string"
+        },
         "options": {
           "additionalProperties": {
             "$ref": "#/$defs/option"
           },
           "type": "object"
-        },
-        "option-name": {
-          "description": "The name of the option/argument.",
-          "type": "string"
         },
         "required": {
           "default": false,

--- a/test/roles/foo/meta/argument_specs.yml
+++ b/test/roles/foo/meta/argument_specs.yml
@@ -21,6 +21,39 @@ argument_specs:
         description:
           - The string value.
           - Has some more text.
+        choices:
+          - foo
+          - bar
+          - baz
+
+      toplevel:
+        type: dict
+        description: Contains more content.
+        options:
+          suboption:
+            type: list
+            elements: int
+            description: A list of special integers.
+            choices:
+              - 1
+              - 2
+              - 3
+              - 123
+
+    seealso:
+      - module: community.foo.bar
+      - module: community.foo.baz
+        description: Baz bam!
+      - plugin: community.foo.bam
+        plugin_type: lookup
+      - plugin: community.foo.bar
+        plugin_type: lookup
+        description: A lookup plugin.
+      - ref: developer_guide
+        description: A link into the Ansible documentation.
+      - link: https://docs.ansible.com/
+        name: The Ansible documentation.
+        description: A link to the Ansible documentation.
 
   alternate:
     short_description: The alternate entry point for the my_app role.

--- a/test/roles/foo/meta/argument_specs.yml
+++ b/test/roles/foo/meta/argument_specs.yml
@@ -26,11 +26,11 @@ argument_specs:
           - bar
           - baz
 
-      toplevel:
+      top_level:
         type: dict
         description: Contains more content.
         options:
-          suboption:
+          sub_option:
             type: list
             elements: int
             description: A list of special integers.


### PR DESCRIPTION
Looks like the JSON errors I had in the beginning of the other PR caused ansible-lint to silently ignore the schema. I didn't notice that I hadn't yet fixed all problems with it...

Here are some more:
1. Add `seealso` support.
2. Add support for sub-`options`.
3. Fix `choices` (right now it produces errors like: `schema: ['rsa', 'p-256', 'p-384', 'p-521'] is not one of ['str', 'list', 'dict', 'bool', 'int', 'float', 'path', 'raw', 'jsonarg', 'json', 'bytes', 'bits'] (schema[arg_specs])`).
