### PR TITLE
Add "become" and "when" properties to dependencies (#277)

### DIFF
--- a/f/ansible-meta.json
+++ b/f/ansible-meta.json
@@ -213,6 +213,10 @@
       ],
       "markdownDescription": "See https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-dependencies and https://github.com/ansible/ansible/blob/devel/lib/ansible/playbook/role/metadata.py#L79",
       "properties": {
+        "become": {
+          "title": "Become",
+          "type": "boolean"
+        },
         "name": {
           "title": "Name",
           "type": "string"
@@ -243,6 +247,10 @@
         },
         "version": {
           "title": "Version",
+          "type": "string"
+        },
+        "when": {
+          "title": "When",
           "type": "string"
         }
       },

--- a/test/roles/meta-tags/meta/main.yml
+++ b/test/roles/meta-tags/meta/main.yml
@@ -7,6 +7,10 @@ dependencies:
     tags: # array of strings allowed
       - apple
       - orange
+  - role: requires_sudo
+    become: true
+  - role: role_with_condition
+    when: inventory_hostname == "foo"
 galaxy_info:
   description: foo
   license: MIT


### PR DESCRIPTION
Although it's not well-documented, these properties do work in an
Ansible role meta/main.yml file.

---

Fixes #277 