### PR TITLE
meta: make galaxy_info section optional

### DIFF
--- a/f/ansible-meta.json
+++ b/f/ansible-meta.json
@@ -1211,7 +1211,6 @@
           "$ref": "#/$defs/GalaxyInfoModel"
         }
       },
-      "required": ["galaxy_info"],
       "type": "object"
     }
   ],

--- a/test/tests/integration/rom_role/meta/main.yml
+++ b/test/tests/integration/rom_role/meta/main.yml
@@ -1,0 +1,3 @@
+---
+# Ansible integration tests do no need a galaxy_info section
+dependencies: []


### PR DESCRIPTION
Related: https://github.com/ansible/ansible-lint/issues/2155
