### PR TITLE
f/ansible-meta.json: Add support for namespace

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -1,5 +1,6 @@
 DISTRO
 Devuan
+FQRN
 Junos
 NXOS
 SLES

--- a/f/ansible-meta.json
+++ b/f/ansible-meta.json
@@ -442,7 +442,7 @@
           "type": "string"
         },
         "namespace": {
-          "markdownDescription": "Use by molecule and ansible-lint to compute FQRN for role not in a collection",
+          "markdownDescription": "Used by molecule and ansible-lint to compute FQRN for roles outside collections",
           "minLength": 2,
           "pattern": "^[a-z][a-z0-9_]+$",
           "title": "Namespace Name",

--- a/f/ansible-meta.json
+++ b/f/ansible-meta.json
@@ -441,6 +441,13 @@
           "title": "Min Ansible Version",
           "type": "string"
         },
+        "namespace": {
+          "markdownDescription": "Use by molecule and ansible-lint to compute FQRN for role not in a collection",
+          "minLength": 2,
+          "pattern": "^[a-z][a-z0-9_]+$",
+          "title": "Namespace Name",
+          "type": "string"
+        },
         "platforms": {
           "items": {
             "anyOf": [

--- a/negative_test/roles/meta_invalid_role_namespace/meta/main.yml
+++ b/negative_test/roles/meta_invalid_role_namespace/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  description: foo
+  min_ansible_version: "2.9"
+  namespace: foo-bar
+  company: foo
+  license: MIT
+  platforms:
+    - name: Alpine
+      versions:
+        - all

--- a/negative_test/roles/meta_invalid_role_namespace/meta/main.yml.md
+++ b/negative_test/roles/meta_invalid_role_namespace/meta/main.yml.md
@@ -1,0 +1,49 @@
+# ajv errors
+
+```json
+  {
+    instancePath: '',
+    schemaPath: '#/anyOf/0/type',
+    keyword: 'type',
+    params: { type: 'null' },
+    message: 'must be null'
+  },
+  {
+    instancePath: '/galaxy_info/namespace',
+    schemaPath: '#/properties/namespace/pattern',
+    keyword: 'pattern',
+    params: { pattern: '^[a-z][a-z0-9_]+$' },
+    message: 'must match pattern "^[a-z][a-z0-9_]+$"'
+  },
+  {
+    instancePath: '',
+    schemaPath: '#/anyOf',
+    keyword: 'anyOf',
+    params: {},
+    message: 'must match a schema in anyOf'
+  }
+]
+```
+
+
+# check-jsonschema
+
+stdout:
+
+```json
+{
+  "status": "fail",
+  "errors": [
+    {
+      "filename": "negative_test/roles/meta_invalid_role_namespace/meta/main.yml",
+      "path": "$",
+      "message": "{'galaxy_info': {'description': 'foo', 'min_ansible_version': '2.9', 'namespace': 'foo-bar', 'company': 'foo', 'license': 'MIT', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}} is not>
+      "has_sub_errors": true,
+      "best_match": {
+        "path": "$",
+        "message": "{'galaxy_info': {'description': 'foo', 'min_ansible_version': '2.9', 'namespace': 'foo-bar', 'company': 'foo', 'license': 'MIT', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}} is n>
+      }
+    }
+  ]
+}
+```

--- a/test/roles/ns/meta/main.yml
+++ b/test/roles/ns/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  description: foo
+  min_ansible_version: "2.9"
+  namespace: foo_bar
+  company: foo
+  license: MIT
+  platforms:
+    - name: Alpine
+      versions:
+        - all


### PR DESCRIPTION
ansible-lint and ansible-compat are advising to use namespace:
in meta/main.yml to define the role FRQN (ref:
https://github.com/ansible/ansible-compat/blob/2aa001d82421557a3bc58207436167e9cd5126c1/src/ansible_compat/constants.py#L22).

So, add support for it.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>