### PR TITLE
src/rebuild.py: deal with python < 3.10

### DIFF
--- a/src/rebuild.py
+++ b/src/rebuild.py
@@ -76,6 +76,8 @@ def is_ref_used(obj: Any, ref: str) -> bool:
 if __name__ == "__main__":
 
     invalid_var_names = sorted(list(keyword.kwlist) + play_keywords)
+    if "__peg_parser__" in invalid_var_names:
+        invalid_var_names.remove("__peg_parser__")
     print("Updating invalid var names")
 
     with open("f/ansible-vars.json", "r+", encoding="utf-8") as f:


### PR DESCRIPTION
In python < 3.10, there's __peg_parser__ keyword, leading to unwanted
changes of src/rebuild.py output. So, add workaround to deal with
that.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>