### PR TITLE
Ensure CI fails if test output change

### DIFF
--- a/.github/workflows/task.yml
+++ b/.github/workflows/task.yml
@@ -28,6 +28,7 @@ jobs:
         task_name:
           - test
           - lint
+          - test_clean
     steps:
       - uses: actions/checkout@v3
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,6 +70,10 @@ tasks:
       - Taskfile.yml
       - tsconfig.json
     interactive: true
+  test_clean:
+    desc: Check that test/ and negative_test/ have no change
+    cmds:
+      - sh -c '[ -z "`git status --porcelain negative_test/ test/`" ]'
   pr:
     desc: Opens a pull request using gh
     deps:

--- a/test/molecule/default/molecule.yml
+++ b/test/molecule/default/molecule.yml
@@ -76,11 +76,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     network_mode: service:vpn
     privileged: true
-    environment: &env
-      http_proxy: "{{ lookup('env', 'http_proxy') }}"
-      https_proxy: "{{ lookup('env', 'https_proxy') }}"
-    ulimits: &ulimit
-      - host
+    environment: *env
+    ulimits: *ulimit
 
 provisioner:
   playbooks:


### PR DESCRIPTION
When running tests, it will create (or modify) a markdown file with
the command outputs. For now, the test are only checking that the commands
are exiting with correct status but not that the output is correct.

This has lead to:
- molecule.yml invalid syntax to go unnoticed
- tests for schema failures were marked as succeeding even if it was
  not due to missing check-jsonschema.

So add a task to check git status of test/ and negative_test/ and
use it inside the github CI. Don't do it by default after running
the tests since it may annoy the developers when adding new tests.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>