### PR TITLE
Make check-jsonschema output more verbose in tests

### DIFF
--- a/negative_test/playbooks/environment.yml.md
+++ b/negative_test/playbooks/environment.yml.md
@@ -100,7 +100,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'environment', 'hosts' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'environment', 'hosts' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'environment': '{{ foo }}-123'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].environment",
+          "message": "'{{ foo }}-123' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].environment",
+          "message": "'{{ foo }}-123' is not of type 'object'"
+        },
+        {
+          "path": "$[0].environment",
+          "message": "'{{ foo }}-123' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/failed_when.yml.md
+++ b/negative_test/playbooks/failed_when.yml.md
@@ -127,7 +127,49 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tasks': [{'name': 'foo', 'ansible.builtin.debug': {'msg': 'foo!'}, 'failed_when': 123}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'name': 'foo', 'ansible.builtin.debug': {'msg': 'foo!'}, 'failed_when': 123} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].failed_when",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].failed_when",
+          "message": "123 is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[0].failed_when",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0].tasks[0].failed_when",
+          "message": "123 is not of type 'array'"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/ignore_errors.yml.md
+++ b/negative_test/playbooks/ignore_errors.yml.md
@@ -145,7 +145,57 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tasks': [{'command': 'echo 123', 'vars': {'should_ignore_errors': True}, 'ignore_errors': 'should_ignore_errors'}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'command': 'echo 123', 'vars': {'should_ignore_errors': True}, 'ignore_errors': 'should_ignore_errors'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].ignore_errors",
+          "message": "'should_ignore_errors' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].ignore_errors",
+          "message": "'should_ignore_errors' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[0].ignore_errors",
+          "message": "'should_ignore_errors' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0].tasks[0].ignore_errors",
+          "message": "'should_ignore_errors' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].ignore_errors",
+          "message": "'should_ignore_errors' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[0].ignore_errors",
+          "message": "'should_ignore_errors' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/import_playbook.yml.md
+++ b/negative_test/playbooks/import_playbook.yml.md
@@ -64,7 +64,25 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "Additional properties are not allowed ('ansible.builtin.import_playbook' was unexpected)"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].ansible.builtin.import_playbook",
+          "message": "{} is not of type 'string'"
+        },
+        {
+          "path": "$[0]",
+          "message": "Additional properties are not allowed ('ansible.builtin.import_playbook' was unexpected)"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'ansible.builtin.import_playbook': {}} should not be valid under {'required': ['ansible.builtin.import_playbook']}"
+        },
+        {
+          "path": "$[0]",
+          "message": "'hosts' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/import_playbook_exclusive.yml.md
+++ b/negative_test/playbooks/import_playbook_exclusive.yml.md
@@ -94,7 +94,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "Additional properties are not allowed ('ansible.builtin.import_playbook', 'import_playbook' were unexpected)"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "{'ansible.builtin.import_playbook': 'foo.yml', 'import_playbook': 'other.yml'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'ansible.builtin.import_playbook': 'foo.yml', 'import_playbook': 'other.yml'} should not be valid under {'required': ['import_playbook']}"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'ansible.builtin.import_playbook': 'foo.yml', 'import_playbook': 'other.yml'} should not be valid under {'required': ['ansible.builtin.import_playbook']}"
+        },
+        {
+          "path": "$[0]",
+          "message": "Additional properties are not allowed ('ansible.builtin.import_playbook', 'import_playbook' were unexpected)"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'ansible.builtin.import_playbook': 'foo.yml', 'import_playbook': 'other.yml'} should not be valid under {'required': ['ansible.builtin.import_playbook']}"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'ansible.builtin.import_playbook': 'foo.yml', 'import_playbook': 'other.yml'} should not be valid under {'required': ['import_playbook']}"
+        },
+        {
+          "path": "$[0]",
+          "message": "'hosts' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/invalid-failed-when.yml.md
+++ b/negative_test/playbooks/invalid-failed-when.yml.md
@@ -179,7 +179,73 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tasks': [{'debug': {'msg': 'failed_when should not accept numeric'}, 'failed_when': 123}, {'debug': {'msg': 'failed_when should not accept sequence'}, 'failed_when': ['foo', 'bar']}, {'debug': {'msg': 'failed_when should not accept map'}, 'failed_when': {}}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'debug': {'msg': 'failed_when should not accept numeric'}, 'failed_when': 123} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].failed_when",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].failed_when",
+          "message": "123 is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[0].failed_when",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0].tasks[0].failed_when",
+          "message": "123 is not of type 'array'"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        },
+        {
+          "path": "$[0].tasks[2]",
+          "message": "{'debug': {'msg': 'failed_when should not accept map'}, 'failed_when': {}} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[2].failed_when",
+          "message": "{} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[2].failed_when",
+          "message": "{} is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[2].failed_when",
+          "message": "{} is not of type 'string'"
+        },
+        {
+          "path": "$[0].tasks[2].failed_when",
+          "message": "{} is not of type 'array'"
+        },
+        {
+          "path": "$[0].tasks[2]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/invalid-serial.yml.md
+++ b/negative_test/playbooks/invalid-serial.yml.md
@@ -109,7 +109,41 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'serial' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'serial' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'serial': '10%BAD'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].serial",
+          "message": "'10%BAD' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].serial",
+          "message": "'10%BAD' is not of type 'integer'"
+        },
+        {
+          "path": "$[0].serial",
+          "message": "'10%BAD' does not match '^\\\\d+\\\\.?\\\\d*%?$'"
+        },
+        {
+          "path": "$[0].serial",
+          "message": "'10%BAD' is not of type 'array'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/invalid.yml.md
+++ b/negative_test/playbooks/invalid.yml.md
@@ -55,7 +55,21 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts' does not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts' does not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "Additional properties are not allowed ('import_playbook' was unexpected)"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'name': 'foo', 'hosts': 'localhost', 'import_playbook': 'included.yml'} should not be valid under {'required': ['import_playbook']}"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/invalid_become.yml.md
+++ b/negative_test/playbooks/invalid_become.yml.md
@@ -102,7 +102,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'become', 'hosts' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'become', 'hosts' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'become': 'yes'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].become",
+          "message": "'yes' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].become",
+          "message": "'yes' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].become",
+          "message": "'yes' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/local_action.yml.md
+++ b/negative_test/playbooks/local_action.yml.md
@@ -103,7 +103,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tasks': [{'local_action': []}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'local_action': []} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].local_action",
+          "message": "[] is not of type 'string', 'object'"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/loop.yml.md
+++ b/negative_test/playbooks/loop.yml.md
@@ -103,7 +103,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tasks': [{'name': 'that should pass', 'ansible.builtin.debug': {'var': 'item'}, 'loop': 123}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'name': 'that should pass', 'ansible.builtin.debug': {'var': 'item'}, 'loop': 123} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].loop",
+          "message": "123 is not of type 'string', 'array'"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/loop2.yml.md
+++ b/negative_test/playbooks/loop2.yml.md
@@ -103,7 +103,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tasks': [{'name': 'that should pass', 'ansible.builtin.debug': {'var': 'item'}, 'loop': {}}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'name': 'that should pass', 'ansible.builtin.debug': {'var': 'item'}, 'loop': {}} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].loop",
+          "message": "{} is not of type 'string', 'array'"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/no_log_partial_template.yml.md
+++ b/negative_test/playbooks/no_log_partial_template.yml.md
@@ -145,7 +145,57 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'vars': {'some_var': True}, 'tasks': [{'ansible.builtin.debug': {'msg': 'foo'}, 'no_log': 'foo-{{ some_var }}'}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'ansible.builtin.debug': {'msg': 'foo'}, 'no_log': 'foo-{{ some_var }}'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'foo-{{ some_var }}' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'foo-{{ some_var }}' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'foo-{{ some_var }}' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'foo-{{ some_var }}' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'foo-{{ some_var }}' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'foo-{{ some_var }}' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/no_log_string.yml.md
+++ b/negative_test/playbooks/no_log_string.yml.md
@@ -145,7 +145,57 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'vars': {'some_var': True}, 'tasks': [{'ansible.builtin.debug': {'msg': 'foo'}, 'no_log': 'some_var'}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'ansible.builtin.debug': {'msg': 'foo'}, 'no_log': 'some_var'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'some_var' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'some_var' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'some_var' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'some_var' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'some_var' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[0].no_log",
+          "message": "'some_var' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/roles.yml.md
+++ b/negative_test/playbooks/roles.yml.md
@@ -84,7 +84,29 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'roles' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'roles' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'roles': 'xxx'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].roles",
+          "message": "'xxx' is not of type 'array'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/run_once_list.yml.md
+++ b/negative_test/playbooks/run_once_list.yml.md
@@ -163,7 +163,57 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tasks': [{'name': 'foo2', 'ansible.builtin.debug': {'msg': 'foo!'}, 'run_once': ['{{ true }}', 'xxx']}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'name': 'foo2', 'ansible.builtin.debug': {'msg': 'foo!'}, 'run_once': ['{{ true }}', 'xxx']} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].run_once",
+          "message": "['{{ true }}', 'xxx'] is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].run_once",
+          "message": "['{{ true }}', 'xxx'] is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[0].run_once",
+          "message": "['{{ true }}', 'xxx'] is not of type 'string'"
+        },
+        {
+          "path": "$[0].tasks[0].run_once",
+          "message": "['{{ true }}', 'xxx'] is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0].run_once",
+          "message": "['{{ true }}', 'xxx'] is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].tasks[0].run_once",
+          "message": "['{{ true }}', 'xxx'] is not of type 'string'"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tags-mapping.yml.md
+++ b/negative_test/playbooks/tags-mapping.yml.md
@@ -116,7 +116,49 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts' does not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts' does not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tags': {}} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not of type 'string'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not of type 'array'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not of type 'string'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not of type 'array'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tags-number.yml.md
+++ b/negative_test/playbooks/tags-number.yml.md
@@ -116,7 +116,49 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts' does not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts' does not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tags': 123} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not of type 'array'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not of type 'array'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks.yml.md
+++ b/negative_test/playbooks/tasks.yml.md
@@ -150,7 +150,41 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'handlers', 'hosts', 'post_tasks', 'pre_tasks', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'handlers', 'hosts', 'post_tasks', 'pre_tasks', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'pre_tasks': 'foo', 'post_tasks': {}, 'tasks': 1, 'handlers': 1.0} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].handlers",
+          "message": "1.0 is not of type 'array', 'null'"
+        },
+        {
+          "path": "$[0].post_tasks",
+          "message": "{} is not of type 'array', 'null'"
+        },
+        {
+          "path": "$[0].pre_tasks",
+          "message": "'foo' is not of type 'array', 'null'"
+        },
+        {
+          "path": "$[0].tasks",
+          "message": "1 is not of type 'array', 'null'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/args_integer.yml.md
+++ b/negative_test/playbooks/tasks/args_integer.yml.md
@@ -73,7 +73,25 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].args",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].args",
+          "message": "123 is not of type 'object'"
+        },
+        {
+          "path": "$[0].args",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/args_string.yml.md
+++ b/negative_test/playbooks/tasks/args_string.yml.md
@@ -64,7 +64,25 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].args",
+          "message": "'{{ }}123' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].args",
+          "message": "'{{ }}123' is not of type 'object'"
+        },
+        {
+          "path": "$[0].args",
+          "message": "'{{ }}123' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/become_method_untemplated.yml.md
+++ b/negative_test/playbooks/tasks/become_method_untemplated.yml.md
@@ -111,7 +111,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].become_method",
+          "message": "'sudo_var' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].become_method",
+          "message": "'sudo_var' is not one of ['sudo', 'su', 'pbrun', 'pfexec', 'runas', 'dzdo', 'ksu', 'doas', 'machinectl']"
+        },
+        {
+          "path": "$[0].become_method",
+          "message": "'sudo_var' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0].become_method",
+          "message": "'sudo_var' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].become_method",
+          "message": "'sudo_var' is not one of ['sudo', 'su', 'pbrun', 'pfexec', 'runas', 'dzdo', 'ksu', 'doas', 'machinectl']"
+        },
+        {
+          "path": "$[0].become_method",
+          "message": "'sudo_var' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/ignore_errors.yml.md
+++ b/negative_test/playbooks/tasks/ignore_errors.yml.md
@@ -91,7 +91,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].ignore_errors",
+          "message": "'should_ignore_errors' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].ignore_errors",
+          "message": "'should_ignore_errors' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].ignore_errors",
+          "message": "'should_ignore_errors' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0].ignore_errors",
+          "message": "'should_ignore_errors' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].ignore_errors",
+          "message": "'should_ignore_errors' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].ignore_errors",
+          "message": "'should_ignore_errors' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/invalid_block.yml.md
+++ b/negative_test/playbooks/tasks/invalid_block.yml.md
@@ -44,7 +44,17 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "{'block': {}} should not be valid under {'required': ['block']}"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "{'block': {}} should not be valid under {'required': ['block']}"
+        },
+        {
+          "path": "$[0].block",
+          "message": "{} is not of type 'array'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/local_action.yml.md
+++ b/negative_test/playbooks/tasks/local_action.yml.md
@@ -49,7 +49,17 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].local_action",
+          "message": "[] is not of type 'string', 'object'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/loop.yml.md
+++ b/negative_test/playbooks/tasks/loop.yml.md
@@ -49,7 +49,17 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].loop",
+          "message": "{} is not of type 'string', 'array'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/loop2.yml.md
+++ b/negative_test/playbooks/tasks/loop2.yml.md
@@ -49,7 +49,17 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].loop",
+          "message": "123 is not of type 'string', 'array'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/no_log_number.yml.md
+++ b/negative_test/playbooks/tasks/no_log_number.yml.md
@@ -109,7 +109,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].no_log",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].no_log",
+          "message": "123 is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].no_log",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0].no_log",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].no_log",
+          "message": "123 is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].no_log",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/no_log_string.yml.md
+++ b/negative_test/playbooks/tasks/no_log_string.yml.md
@@ -91,7 +91,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].no_log",
+          "message": "'some_var' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].no_log",
+          "message": "'some_var' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].no_log",
+          "message": "'some_var' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0].no_log",
+          "message": "'some_var' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].no_log",
+          "message": "'some_var' is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].no_log",
+          "message": "'some_var' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/tags-mapping.yml.md
+++ b/negative_test/playbooks/tasks/tags-mapping.yml.md
@@ -87,7 +87,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].tags",
+          "message": "{} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not of type 'string'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not of type 'array'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not of type 'string'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "{} is not of type 'array'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/tags-string.yml.md
+++ b/negative_test/playbooks/tasks/tags-string.yml.md
@@ -87,7 +87,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].tags",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not of type 'array'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0].tags",
+          "message": "123 is not of type 'array'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/when_integer.yml.md
+++ b/negative_test/playbooks/tasks/when_integer.yml.md
@@ -109,7 +109,45 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].when",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].when",
+          "message": "123 is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].when",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0].when",
+          "message": "123 is not of type 'array'"
+        },
+        {
+          "path": "$[0].when",
+          "message": "123 is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].when",
+          "message": "123 is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].when",
+          "message": "123 is not of type 'string'"
+        },
+        {
+          "path": "$[0].when",
+          "message": "123 is not of type 'array'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/when_object.yml.md
+++ b/negative_test/playbooks/tasks/when_object.yml.md
@@ -109,7 +109,45 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].when",
+          "message": "{} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].when",
+          "message": "{} is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].when",
+          "message": "{} is not of type 'string'"
+        },
+        {
+          "path": "$[0].when",
+          "message": "{} is not of type 'array'"
+        },
+        {
+          "path": "$[0].when",
+          "message": "{} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].when",
+          "message": "{} is not of type 'boolean'"
+        },
+        {
+          "path": "$[0].when",
+          "message": "{} is not of type 'string'"
+        },
+        {
+          "path": "$[0].when",
+          "message": "{} is not of type 'array'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/with_items_boolean.yml.md
+++ b/negative_test/playbooks/tasks/with_items_boolean.yml.md
@@ -62,7 +62,25 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].with_items",
+          "message": "True is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].with_items",
+          "message": "True is not of type 'string'"
+        },
+        {
+          "path": "$[0].with_items",
+          "message": "True is not of type 'array'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/tasks/with_items_untemplated_string.yml.md
+++ b/negative_test/playbooks/tasks/with_items_untemplated_string.yml.md
@@ -62,7 +62,25 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'block' is a required property"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0].with_items",
+          "message": "'foobar' is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].with_items",
+          "message": "'foobar' does not match '^\\\\{\\\\{.*\\\\}\\\\}$'"
+        },
+        {
+          "path": "$[0].with_items",
+          "message": "'foobar' is not of type 'array'"
+        },
+        {
+          "path": "$[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/vars/asterisk.yml.md
+++ b/negative_test/playbooks/vars/asterisk.yml.md
@@ -55,7 +55,21 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "'*foo' does not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "'*foo' does not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
+        },
+        {
+          "path": "$",
+          "message": "{'*foo': '...'} is not of type 'string'"
+        },
+        {
+          "path": "$",
+          "message": "{'*foo': '...'} is not of type 'null'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/vars/dash-in-var-name.yml.md
+++ b/negative_test/playbooks/vars/dash-in-var-name.yml.md
@@ -55,7 +55,21 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "'foo-bar' does not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "'foo-bar' does not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
+        },
+        {
+          "path": "$",
+          "message": "{'foo-bar': '...'} is not of type 'string'"
+        },
+        {
+          "path": "$",
+          "message": "{'foo-bar': '...'} is not of type 'null'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/vars/list.yml.md
+++ b/negative_test/playbooks/vars/list.yml.md
@@ -55,7 +55,21 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "['foo', 'bar'] is not of type 'object'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "['foo', 'bar'] is not of type 'object'"
+        },
+        {
+          "path": "$",
+          "message": "['foo', 'bar'] is not of type 'string'"
+        },
+        {
+          "path": "$",
+          "message": "['foo', 'bar'] is not of type 'null'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/vars/numeric-var-name.yml.md
+++ b/negative_test/playbooks/vars/numeric-var-name.yml.md
@@ -55,7 +55,21 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "'12' does not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "'12' does not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
+        },
+        {
+          "path": "$",
+          "message": "{'12': '...'} is not of type 'string'"
+        },
+        {
+          "path": "$",
+          "message": "{'12': '...'} is not of type 'null'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/vars/play-keyword.yml.md
+++ b/negative_test/playbooks/vars/play-keyword.yml.md
@@ -55,7 +55,21 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "'environment' does not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "'environment' does not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
+        },
+        {
+          "path": "$",
+          "message": "{'environment': '...'} is not of type 'string'"
+        },
+        {
+          "path": "$",
+          "message": "{'environment': '...'} is not of type 'null'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/vars/python-keyword.yml.md
+++ b/negative_test/playbooks/vars/python-keyword.yml.md
@@ -64,7 +64,21 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "'async', 'lambda' do not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "'async', 'lambda' do not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
+        },
+        {
+          "path": "$",
+          "message": "{'async': '...', 'lambda': '...'} is not of type 'string'"
+        },
+        {
+          "path": "$",
+          "message": "{'async': '...', 'lambda': '...'} is not of type 'null'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/vars/varname-numeric-prefix.yml.md
+++ b/negative_test/playbooks/vars/varname-numeric-prefix.yml.md
@@ -55,7 +55,21 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "'5foo' does not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "'5foo' does not match any of the regexes: '^(?!(False|None|True|and|any_errors_fatal|as|assert|async|await|become|become_exe|become_flags|become_method|become_user|break|check_mode|class|collections|connection|continue|debugger|def|del|diff|elif|else|environment|except|fact_path|finally|for|force_handlers|from|gather_facts|gather_subset|gather_timeout|global|handlers|hosts|if|ignore_errors|ignore_unreachable|import|in|is|lambda|max_fail_percentage|module_defaults|name|no_log|nonlocal|not|or|order|pass|port|post_tasks|pre_tasks|raise|remote_user|return|roles|run_once|serial|strategy|tags|tasks|throttle|timeout|try|vars|vars_files|vars_prompt|while|with|yield)$)[a-zA-Z_][\\\\w]*$'"
+        },
+        {
+          "path": "$",
+          "message": "{'5foo': '...'} is not of type 'string'"
+        },
+        {
+          "path": "$",
+          "message": "{'5foo': '...'} is not of type 'null'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/vas_prompt.yml.md
+++ b/negative_test/playbooks/vas_prompt.yml.md
@@ -84,7 +84,33 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts' does not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts' does not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'vars_prompt': [{'name': 'username', 'prompt': 'What is your username?', 'private': False, 'tags': ['foo']}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].vars_prompt",
+          "message": "[{'name': 'username', 'prompt': 'What is your username?', 'private': False, 'tags': ['foo']}] is not of type 'object'"
+        },
+        {
+          "path": "$[0].vars_prompt[0]",
+          "message": "Additional properties are not allowed ('tags' was unexpected)"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/with_cartesian.yml.md
+++ b/negative_test/playbooks/with_cartesian.yml.md
@@ -98,7 +98,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tasks': [{'ansible.builtin.debug': {'msg': '{{ item }}'}, 'with_cartesian': []}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'ansible.builtin.debug': {'msg': '{{ item }}'}, 'with_cartesian': []} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'ansible.builtin.debug': {'msg': '{{ item }}'}, 'with_cartesian': []} should not be valid under {'required': ['with_cartesian']}"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/with_filetree.yml.md
+++ b/negative_test/playbooks/with_filetree.yml.md
@@ -98,7 +98,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tasks': [{'ansible.builtin.debug': {'msg': '{{ item }}'}, 'with_filetree': 'foo'}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'ansible.builtin.debug': {'msg': '{{ item }}'}, 'with_filetree': 'foo'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'ansible.builtin.debug': {'msg': '{{ item }}'}, 'with_filetree': 'foo'} should not be valid under {'required': ['with_filetree']}"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/playbooks/with_flattened.yml.md
+++ b/negative_test/playbooks/with_flattened.yml.md
@@ -98,7 +98,37 @@ stdout:
       "best_match": {
         "path": "$[0]",
         "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$[0]",
+          "message": "'hosts', 'tasks' do not match any of the regexes: '^(ansible\\\\.builtin\\\\.)?import_playbook$', 'name', 'tags', 'vars'"
+        },
+        {
+          "path": "$[0]",
+          "message": "{'hosts': 'localhost', 'tasks': [{'ansible.builtin.debug': {'msg': '{{ item }}'}, 'with_flattened': 'foo'}]} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0]",
+          "message": "'ansible.builtin.import_playbook' is a required property"
+        },
+        {
+          "path": "$[0]",
+          "message": "'import_playbook' is a required property"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'ansible.builtin.debug': {'msg': '{{ item }}'}, 'with_flattened': 'foo'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "{'ansible.builtin.debug': {'msg': '{{ item }}'}, 'with_flattened': 'foo'} should not be valid under {'required': ['with_flattened']}"
+        },
+        {
+          "path": "$[0].tasks[0]",
+          "message": "'block' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/reqs3/meta/requirements.yml.md
+++ b/negative_test/reqs3/meta/requirements.yml.md
@@ -71,7 +71,29 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "{'foo': 'bar'} is not of type 'array'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "{'foo': 'bar'} is not of type 'array'"
+        },
+        {
+          "path": "$",
+          "message": "Additional properties are not allowed ('foo' was unexpected)"
+        },
+        {
+          "path": "$",
+          "message": "{'foo': 'bar'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$",
+          "message": "'collections' is a required property"
+        },
+        {
+          "path": "$",
+          "message": "'roles' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/roles/meta/main.yml.md
+++ b/negative_test/roles/meta/main.yml.md
@@ -46,7 +46,17 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "{'galaxy_info': {'description': 'bar', 'min_ansible_version': '2.9', 'company': 'foo', 'license': 'MIT', 'galaxy_tags': 'database', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}} is not of type 'null'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "{'galaxy_info': {'description': 'bar', 'min_ansible_version': '2.9', 'company': 'foo', 'license': 'MIT', 'galaxy_tags': 'database', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}} is not of type 'null'"
+        },
+        {
+          "path": "$.galaxy_info.galaxy_tags",
+          "message": "'database' is not of type 'array'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/roles/meta_invalid_collection/meta/main.yml.md
+++ b/negative_test/roles/meta_invalid_collection/meta/main.yml.md
@@ -46,7 +46,17 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "{'collections': ['foo'], 'galaxy_info': {'description': 'foo', 'license': 'bar', 'min_ansible_version': '2.10', 'platforms': [{'name': 'Fedora', 'versions': ['all']}]}} is not of type 'null'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "{'collections': ['foo'], 'galaxy_info': {'description': 'foo', 'license': 'bar', 'min_ansible_version': '2.10', 'platforms': [{'name': 'Fedora', 'versions': ['all']}]}} is not of type 'null'"
+        },
+        {
+          "path": "$.collections[0]",
+          "message": "'foo' does not match '^[a-z_]+\\\\.[a-z_]+$'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/roles/meta_invalid_collections/meta/main.yml.md
+++ b/negative_test/roles/meta_invalid_collections/meta/main.yml.md
@@ -46,7 +46,17 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "{'collections': ['FOO.BAR'], 'galaxy_info': {'description': 'foo', 'license': 'bar', 'min_ansible_version': '2.10', 'platforms': [{'name': 'Fedora', 'versions': ['all']}]}} is not of type 'null'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "{'collections': ['FOO.BAR'], 'galaxy_info': {'description': 'foo', 'license': 'bar', 'min_ansible_version': '2.10', 'platforms': [{'name': 'Fedora', 'versions': ['all']}]}} is not of type 'null'"
+        },
+        {
+          "path": "$.collections[0]",
+          "message": "'FOO.BAR' does not match '^[a-z_]+\\\\.[a-z_]+$'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/roles/meta_invalid_role_namespace/meta/main.yml.md
+++ b/negative_test/roles/meta_invalid_role_namespace/meta/main.yml.md
@@ -46,7 +46,17 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "{'galaxy_info': {'description': 'foo', 'min_ansible_version': '2.9', 'namespace': 'foo-bar', 'company': 'foo', 'license': 'MIT', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}} is not of type 'null'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "{'galaxy_info': {'description': 'foo', 'min_ansible_version': '2.9', 'namespace': 'foo-bar', 'company': 'foo', 'license': 'MIT', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}} is not of type 'null'"
+        },
+        {
+          "path": "$.galaxy_info.namespace",
+          "message": "'foo-bar' does not match '^[a-z][a-z0-9_]+$'"
+        }
+      ]
     }
   ]
 }

--- a/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml.md
+++ b/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml.md
@@ -71,7 +71,29 @@ stdout:
       "best_match": {
         "path": "$",
         "message": "{'galaxy_info': {'description': 'bar', 'min_ansible_version': '2.9', 'company': 'foo', 'license': 'MIT', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}, 'dependencies': [{'version': 'foo'}]} is not of type 'null'"
-      }
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "{'galaxy_info': {'description': 'bar', 'min_ansible_version': '2.9', 'company': 'foo', 'license': 'MIT', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}, 'dependencies': [{'version': 'foo'}]} is not of type 'null'"
+        },
+        {
+          "path": "$.dependencies[0]",
+          "message": "{'version': 'foo'} is not valid under any of the given schemas"
+        },
+        {
+          "path": "$.dependencies[0]",
+          "message": "'role' is a required property"
+        },
+        {
+          "path": "$.dependencies[0]",
+          "message": "'src' is a required property"
+        },
+        {
+          "path": "$.dependencies[0]",
+          "message": "'name' is a required property"
+        }
+      ]
     }
   ]
 }

--- a/src/schema.spec.ts
+++ b/src/schema.spec.ts
@@ -74,7 +74,7 @@ describe("schemas under f/", function () {
             // reason, nodejs environment lacks some env variables needed
             // and breaks usage from inside virtualenvs.
             const proc = spawnSync(
-              `check-jsonschema -o json --schemafile f/${schema_file} ${test_file}`,
+              `check-jsonschema -v -o json --schemafile f/${schema_file} ${test_file}`,
               { shell: true, encoding: "utf-8", stdio: "pipe" }
             );
             if (proc.status != 0) {


### PR DESCRIPTION
Since support for import_playbooks has been added, the output of check-jsonschema will only output the error due to the play not matching the import_playbook schema (which is a normal thing) but won't show the actual error, so use -v to see all errors.