### PR TITLE
meta: ensure galaxy_info.author field is a valid github username

### DIFF
--- a/f/ansible-meta.json
+++ b/f/ansible-meta.json
@@ -404,8 +404,9 @@
       "additionalProperties": false,
       "properties": {
         "author": {
+          "markdownDescription": "The author of the role as a github username. If that is not a standalone role (outside a collection), you can remove galaxy_info.author field, as collections do not use it.",
           "minLength": 2,
-          "pattern": "^[a-z0-9][a-z0-9_]+$",
+          "pattern": "^[a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38}$",
           "title": "Author",
           "type": "string"
         },

--- a/negative_test/roles/v1_meta_author/meta/main.yml
+++ b/negative_test/roles/v1_meta_author/meta/main.yml
@@ -1,0 +1,12 @@
+---
+# v1 role meta (standalone)
+galaxy_info:
+  author: foo.bar # <-- that is a valid author name because is not a valid github username
+  description: foo
+  min_ansible_version: "2.9"
+  company: foo
+  license: MIT
+  platforms:
+    - name: Alpine
+      versions:
+        - all

--- a/negative_test/roles/v1_meta_author/meta/main.yml.md
+++ b/negative_test/roles/v1_meta_author/meta/main.yml.md
@@ -1,0 +1,64 @@
+# ajv errors
+
+```json
+[
+  {
+    "instancePath": "",
+    "keyword": "type",
+    "message": "must be null",
+    "params": {
+      "type": "null"
+    },
+    "schemaPath": "#/anyOf/0/type"
+  },
+  {
+    "instancePath": "/galaxy_info/author",
+    "keyword": "pattern",
+    "message": "must match pattern \"^[a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38}$\"",
+    "params": {
+      "pattern": "^[a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38}$"
+    },
+    "schemaPath": "#/properties/author/pattern"
+  },
+  {
+    "instancePath": "",
+    "keyword": "anyOf",
+    "message": "must match a schema in anyOf",
+    "params": {},
+    "schemaPath": "#/anyOf"
+  }
+]
+```
+
+# check-jsonschema
+
+stdout:
+
+```json
+{
+  "status": "fail",
+  "errors": [
+    {
+      "filename": "negative_test/roles/v1_meta_author/meta/main.yml",
+      "path": "$",
+      "message": "{'galaxy_info': {'author': 'foo.bar', 'description': 'foo', 'min_ansible_version': '2.9', 'company': 'foo', 'license': 'MIT', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}} is not valid under any of the given schemas",
+      "has_sub_errors": true,
+      "best_match": {
+        "path": "$",
+        "message": "{'galaxy_info': {'author': 'foo.bar', 'description': 'foo', 'min_ansible_version': '2.9', 'company': 'foo', 'license': 'MIT', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}} is not of type 'null'"
+      },
+      "sub_errors": [
+        {
+          "path": "$",
+          "message": "{'galaxy_info': {'author': 'foo.bar', 'description': 'foo', 'min_ansible_version': '2.9', 'company': 'foo', 'license': 'MIT', 'platforms': [{'name': 'Alpine', 'versions': ['all']}]}} is not of type 'null'"
+        },
+        {
+          "path": "$.galaxy_info.author",
+          "message": "'foo.bar' does not match '^[a-z\\\\d](?:[a-z\\\\d]|-(?=[a-z\\\\d])){0,38}$'"
+        }
+      ]
+    }
+  ],
+  "parse_errors": []
+}
+```

--- a/test/roles/v1_role/meta/main.yml
+++ b/test/roles/v1_role/meta/main.yml
@@ -1,0 +1,12 @@
+---
+# v1 role meta (standalone)
+galaxy_info:
+  author: foo-bar # <-- that is a valid author name because is a valid github username
+  description: foo
+  min_ansible_version: "2.9"
+  company: foo
+  license: MIT
+  platforms:
+    - name: Alpine
+      versions:
+        - all


### PR DESCRIPTION
As v1 roles (standalone) used the author field as a github username and all documentation examples uses it as a username, we require it to match their requirements.

We also document the fact that `galaxy_info.author` field is not needed for roles inside collections and that it can be removed.

This change will be followed by few others which will add versioning support for meta schema, so we can distinguish between standalone roles and in-collection roles, as they have different-enough requirements. 

### Reasoning

While Galaxy metadata official page does not mention any limitations for the author field, we can see on multiple examples from https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#finding-roles-on-galaxy that this is expected to be the github username. That is also in sync with behavior of other tools like ansible-lint and navigator which would use this field to build the fully qualified role name, as old standalone (v1) roles do not have a specific field for namespace.

Shortly, to avoid problems, just use a github compatible username or don't use the field at all.