### PR TITLE
Replace meta version with galaxy_info.standalone

### DIFF
--- a/f/ansible-meta.json
+++ b/f/ansible-meta.json
@@ -400,8 +400,19 @@
       "title": "FreeBSDPlatformModel",
       "type": "object"
     },
-    "GalaxyInfoModel-v1": {
+    "GalaxyInfoModel": {
       "additionalProperties": false,
+      "else": {
+        "$comment": "If standalone is false, then we have a collection role and only description is required",
+        "required": ["description"]
+      },
+      "if": {
+        "properties": {
+          "standalone": {
+            "const": true
+          }
+        }
+      },
       "properties": {
         "author": {
           "title": "Author",
@@ -454,14 +465,23 @@
           "pattern": "^[a-z][a-z0-9_]+$",
           "title": "Role Name",
           "type": "string"
+        },
+        "standalone": {
+          "description:": "Set to true for old standalone roles, or false for new collection roles.",
+          "title": "Standalone",
+          "type": "boolean"
         }
       },
-      "required": [
-        "description",
-        "license",
-        "min_ansible_version",
-        "platforms"
-      ],
+      "then": {
+        "$comment": "Standalone role, so we require several fields.",
+        "required": [
+          "standalone",
+          "description",
+          "license",
+          "min_ansible_version",
+          "platforms"
+        ]
+      },
       "title": "GalaxyInfoModel for old standalone role (v1)",
       "type": "object"
     },
@@ -486,7 +506,8 @@
         },
         "platforms": {
           "$ref": "#/$defs/platforms"
-        }
+        },
+        "standalone": { "const": false }
       },
       "required": ["description"],
       "title": "GalaxyInfoModel for role within a collection (v2)",
@@ -1281,79 +1302,6 @@
       "title": "Platforms",
       "type": "array"
     },
-    "v1": {
-      "additionalProperties": false,
-      "properties": {
-        "allow_duplicates": {
-          "title": "Allow Duplicates",
-          "type": "boolean"
-        },
-        "cloud_platforms": {
-          "items": {
-            "enum": [
-              "amazon",
-              "azure",
-              "centurylink",
-              "google",
-              "openstack",
-              "ovirt",
-              "rackspace",
-              "vmware"
-            ],
-            "type": "string"
-          },
-          "markdownDescription": "Which cloud platforms are supported, existing values can be gathered using the [API](https://galaxy.ansible.com/api/v1/cloud_platforms/)",
-          "title": "Cloud Platforms",
-          "type": "array"
-        },
-        "collections": {
-          "$ref": "#/$defs/collections"
-        },
-        "dependencies": {
-          "items": {
-            "$ref": "#/$defs/DependencyModel"
-          },
-          "title": "Dependencies",
-          "type": "array"
-        },
-        "galaxy_info": {
-          "$ref": "#/$defs/GalaxyInfoModel-v1"
-        },
-        "version": {
-          "const": 1
-        }
-      },
-      "required": ["version"],
-      "title": "Meta Schema v1 (standalone role)",
-      "type": "object"
-    },
-    "v2": {
-      "additionalProperties": false,
-      "properties": {
-        "allow_duplicates": {
-          "title": "Allow Duplicates",
-          "type": "boolean"
-        },
-        "collections": {
-          "$ref": "#/$defs/collections"
-        },
-        "dependencies": {
-          "items": {
-            "$ref": "#/$defs/DependencyModel"
-          },
-          "title": "Dependencies",
-          "type": "array"
-        },
-        "galaxy_info": {
-          "$ref": "#/$defs/GalaxyInfoModel-v2"
-        },
-        "version": {
-          "const": 2
-        }
-      },
-      "title": "Meta Schema v2 (role inside collection)",
-      "type": "object"
-    },
     "vCenterPlatformModel": {
       "properties": {
         "name": {
@@ -1395,26 +1343,28 @@
   },
   "$id": "https://raw.githubusercontent.com/ansible/schemas/main/f/ansible-meta.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "else": {
-    "$ref": "#/$defs/v2"
-  },
   "examples": ["meta/main.yml"],
-  "if": {
-    "properties": {
-      "version": {
-        "const": 1
-      }
-    }
-  },
   "properties": {
-    "version": {
-      "enum": [1, 2],
-      "type": "integer"
+    "additionalProperties": false,
+    "allow_duplicates": {
+      "title": "Allow Duplicates",
+      "type": "boolean"
+    },
+    "collections": {
+      "$ref": "#/$defs/collections"
+    },
+    "dependencies": {
+      "items": {
+        "$ref": "#/$defs/DependencyModel"
+      },
+      "title": "Dependencies",
+      "type": "array"
+    },
+    "galaxy_info": {
+      "$ref": "#/$defs/GalaxyInfoModel"
     }
   },
-  "then": {
-    "$ref": "#/$defs/v1"
-  },
+  "required": ["galaxy_info"],
   "title": "Ansible Meta Schema v1/v2",
   "type": "object"
 }

--- a/negative_test/roles/empty_meta/meta/main.yml.md
+++ b/negative_test/roles/empty_meta/meta/main.yml.md
@@ -10,24 +10,6 @@
       "type": "object"
     },
     "schemaPath": "#/type"
-  },
-  {
-    "instancePath": "",
-    "keyword": "if",
-    "message": "must match \"then\" schema",
-    "params": {
-      "failingKeyword": "then"
-    },
-    "schemaPath": "#/if"
-  },
-  {
-    "instancePath": "",
-    "keyword": "type",
-    "message": "must be object",
-    "params": {
-      "type": "object"
-    },
-    "schemaPath": "#/type"
   }
 ]
 ```
@@ -40,12 +22,6 @@ stdout:
 {
   "status": "fail",
   "errors": [
-    {
-      "filename": "negative_test/roles/empty_meta/meta/main.yml",
-      "path": "$",
-      "message": "None is not of type 'object'",
-      "has_sub_errors": false
-    },
     {
       "filename": "negative_test/roles/empty_meta/meta/main.yml",
       "path": "$",

--- a/negative_test/roles/meta/main.yml.md
+++ b/negative_test/roles/meta/main.yml.md
@@ -3,6 +3,24 @@
 ```json
 [
   {
+    "instancePath": "/galaxy_info",
+    "keyword": "required",
+    "message": "must have required property 'standalone'",
+    "params": {
+      "missingProperty": "standalone"
+    },
+    "schemaPath": "#/then/required"
+  },
+  {
+    "instancePath": "/galaxy_info",
+    "keyword": "if",
+    "message": "must match \"then\" schema",
+    "params": {
+      "failingKeyword": "then"
+    },
+    "schemaPath": "#/if"
+  },
+  {
     "instancePath": "/galaxy_info/galaxy_tags",
     "keyword": "type",
     "message": "must be array",
@@ -10,15 +28,6 @@
       "type": "array"
     },
     "schemaPath": "#/properties/galaxy_tags/type"
-  },
-  {
-    "instancePath": "",
-    "keyword": "if",
-    "message": "must match \"then\" schema",
-    "params": {
-      "failingKeyword": "then"
-    },
-    "schemaPath": "#/if"
   }
 ]
 ```
@@ -31,6 +40,12 @@ stdout:
 {
   "status": "fail",
   "errors": [
+    {
+      "filename": "negative_test/roles/meta/main.yml",
+      "path": "$.galaxy_info",
+      "message": "'standalone' is a required property",
+      "has_sub_errors": false
+    },
     {
       "filename": "negative_test/roles/meta/main.yml",
       "path": "$.galaxy_info.galaxy_tags",

--- a/negative_test/roles/meta_invalid_collection/meta/main.yml.md
+++ b/negative_test/roles/meta_invalid_collection/meta/main.yml.md
@@ -12,11 +12,29 @@
     "schemaPath": "#/$defs/collections/items/pattern"
   },
   {
-    "instancePath": "",
-    "keyword": "if",
-    "message": "must match \"else\" schema",
+    "instancePath": "/galaxy_info",
+    "keyword": "required",
+    "message": "must have required property 'standalone'",
     "params": {
-      "failingKeyword": "else"
+      "missingProperty": "standalone"
+    },
+    "schemaPath": "#/then/required"
+  },
+  {
+    "instancePath": "/galaxy_info",
+    "keyword": "required",
+    "message": "must have required property 'min_ansible_version'",
+    "params": {
+      "missingProperty": "min_ansible_version"
+    },
+    "schemaPath": "#/then/required"
+  },
+  {
+    "instancePath": "/galaxy_info",
+    "keyword": "if",
+    "message": "must match \"then\" schema",
+    "params": {
+      "failingKeyword": "then"
     },
     "schemaPath": "#/if"
   }
@@ -35,6 +53,18 @@ stdout:
       "filename": "negative_test/roles/meta_invalid_collection/meta/main.yml",
       "path": "$.collections[0]",
       "message": "'foo' does not match '^[a-z_]+\\\\.[a-z_]+$'",
+      "has_sub_errors": false
+    },
+    {
+      "filename": "negative_test/roles/meta_invalid_collection/meta/main.yml",
+      "path": "$.galaxy_info",
+      "message": "'standalone' is a required property",
+      "has_sub_errors": false
+    },
+    {
+      "filename": "negative_test/roles/meta_invalid_collection/meta/main.yml",
+      "path": "$.galaxy_info",
+      "message": "'min_ansible_version' is a required property",
       "has_sub_errors": false
     }
   ],

--- a/negative_test/roles/meta_invalid_collections/meta/main.yml.md
+++ b/negative_test/roles/meta_invalid_collections/meta/main.yml.md
@@ -12,11 +12,29 @@
     "schemaPath": "#/$defs/collections/items/pattern"
   },
   {
-    "instancePath": "",
-    "keyword": "if",
-    "message": "must match \"else\" schema",
+    "instancePath": "/galaxy_info",
+    "keyword": "required",
+    "message": "must have required property 'standalone'",
     "params": {
-      "failingKeyword": "else"
+      "missingProperty": "standalone"
+    },
+    "schemaPath": "#/then/required"
+  },
+  {
+    "instancePath": "/galaxy_info",
+    "keyword": "required",
+    "message": "must have required property 'min_ansible_version'",
+    "params": {
+      "missingProperty": "min_ansible_version"
+    },
+    "schemaPath": "#/then/required"
+  },
+  {
+    "instancePath": "/galaxy_info",
+    "keyword": "if",
+    "message": "must match \"then\" schema",
+    "params": {
+      "failingKeyword": "then"
     },
     "schemaPath": "#/if"
   }
@@ -35,6 +53,18 @@ stdout:
       "filename": "negative_test/roles/meta_invalid_collections/meta/main.yml",
       "path": "$.collections[0]",
       "message": "'FOO.BAR' does not match '^[a-z_]+\\\\.[a-z_]+$'",
+      "has_sub_errors": false
+    },
+    {
+      "filename": "negative_test/roles/meta_invalid_collections/meta/main.yml",
+      "path": "$.galaxy_info",
+      "message": "'standalone' is a required property",
+      "has_sub_errors": false
+    },
+    {
+      "filename": "negative_test/roles/meta_invalid_collections/meta/main.yml",
+      "path": "$.galaxy_info",
+      "message": "'min_ansible_version' is a required property",
       "has_sub_errors": false
     }
   ],

--- a/negative_test/roles/meta_invalid_role_namespace/meta/main.yml.md
+++ b/negative_test/roles/meta_invalid_role_namespace/meta/main.yml.md
@@ -3,6 +3,24 @@
 ```json
 [
   {
+    "instancePath": "/galaxy_info",
+    "keyword": "required",
+    "message": "must have required property 'standalone'",
+    "params": {
+      "missingProperty": "standalone"
+    },
+    "schemaPath": "#/then/required"
+  },
+  {
+    "instancePath": "/galaxy_info",
+    "keyword": "if",
+    "message": "must match \"then\" schema",
+    "params": {
+      "failingKeyword": "then"
+    },
+    "schemaPath": "#/if"
+  },
+  {
     "instancePath": "/galaxy_info/namespace",
     "keyword": "pattern",
     "message": "must match pattern \"^[a-z][a-z0-9_]+$\"",
@@ -10,15 +28,6 @@
       "pattern": "^[a-z][a-z0-9_]+$"
     },
     "schemaPath": "#/properties/namespace/pattern"
-  },
-  {
-    "instancePath": "",
-    "keyword": "if",
-    "message": "must match \"then\" schema",
-    "params": {
-      "failingKeyword": "then"
-    },
-    "schemaPath": "#/if"
   }
 ]
 ```
@@ -31,6 +40,12 @@ stdout:
 {
   "status": "fail",
   "errors": [
+    {
+      "filename": "negative_test/roles/meta_invalid_role_namespace/meta/main.yml",
+      "path": "$.galaxy_info",
+      "message": "'standalone' is a required property",
+      "has_sub_errors": false
+    },
     {
       "filename": "negative_test/roles/meta_invalid_role_namespace/meta/main.yml",
       "path": "$.galaxy_info.namespace",

--- a/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml.md
+++ b/negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml.md
@@ -37,7 +37,16 @@
     "schemaPath": "#/anyOf"
   },
   {
-    "instancePath": "",
+    "instancePath": "/galaxy_info",
+    "keyword": "required",
+    "message": "must have required property 'standalone'",
+    "params": {
+      "missingProperty": "standalone"
+    },
+    "schemaPath": "#/then/required"
+  },
+  {
+    "instancePath": "/galaxy_info",
     "keyword": "if",
     "message": "must match \"then\" schema",
     "params": {
@@ -79,6 +88,12 @@ stdout:
           "message": "'name' is a required property"
         }
       ]
+    },
+    {
+      "filename": "negative_test/roles/role_with_bad_deps_in_meta/meta/main.yml",
+      "path": "$.galaxy_info",
+      "message": "'standalone' is a required property",
+      "has_sub_errors": false
     }
   ],
   "parse_errors": []

--- a/test/roles/foo/meta/main.yml
+++ b/test/roles/foo/meta/main.yml
@@ -1,4 +1,3 @@
-version: 1 # v1 role meta (standalone)
 collections:
   - foo.bar
 dependencies:
@@ -35,6 +34,7 @@ dependencies:
     name: http-role
 
 galaxy_info:
+  standalone: true
   description: foo
   min_ansible_version: "2.9"
   company: foo

--- a/test/roles/maximum/meta/main.yml
+++ b/test/roles/maximum/meta/main.yml
@@ -1,6 +1,6 @@
-version: 1 # v1 role meta (standalone)
 allow_duplicates: true
 galaxy_info:
+  standalone: true # v1 role meta (standalone)
   description: maximum
   min_ansible_version: "2.9"
   company: foo

--- a/test/roles/meta-tags/meta/main.yml
+++ b/test/roles/meta-tags/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 # https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-dependencies
-version: 1 # v1 role meta (standalone)
 dependencies:
   - role: foo
     tags: fruit # simple string allowed
@@ -18,6 +17,7 @@ dependencies:
     vars:
       "foo": bar
 galaxy_info:
+  standalone: true
   description: foo
   license: MIT
   min_ansible_version: "2.10"

--- a/test/roles/ns/meta/main.yml
+++ b/test/roles/ns/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 version: 1 # v1 role meta (standalone)
 galaxy_info:
+  standalone: true
   description: foo
   min_ansible_version: "2.9"
   namespace: foo_bar

--- a/test/roles/v1_role/meta/main.yml
+++ b/test/roles/v1_role/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 version: 1 # v1 role meta (standalone)
 galaxy_info:
+  standalone: true
   author: foo-bar # <-- that is a valid author name because is a valid github username
   description: foo
   min_ansible_version: "2.9"

--- a/test/tests/integration/rom_role/meta/main.yml
+++ b/test/tests/integration/rom_role/meta/main.yml
@@ -1,4 +1,5 @@
 ---
-# Ansible integration tests do no need a galaxy_info section
 dependencies: []
-version: 1
+galaxy_info:
+  standalone: false
+  description: foo


### PR DESCRIPTION
As ansible does not allow adding new properties as root of meta files, we introduce a `galaxy_info.standalone` field, of type bool, so we can distinguish between a standalone role and a collection one.

Fixing regression introduced by #384 as ansible does not load roles with extra properties at root level but it does allow any extra properties inside `galaxy_info`. We decided to use
`standalone` instead of version, as a version field under galaxy_info would confuse users
into believing that is the version of the role itself, and not the metadata schema version.

Fixes: #386