### PR TITLE
Remove user property from tasks, roles and block

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,6 +49,7 @@ tasks:
     cmds:
       - $VIRTUAL_ENV/bin/python3 -m pre_commit run -a
       - task: summary
+    run: once # avoid duplicate runs as all task depend on this
     silent: true
     sources:
       - "*"
@@ -71,9 +72,9 @@ tasks:
       - task: summary
     sources:
       - f/**
-      - negative_test/**
-      - test/**
-      - src/**
+      - negative_test/**/*.*
+      - test/**/*.*
+      - src/**/*.*
       - package.json
       - package-lock.json
       - Taskfile.yml

--- a/f/ansible-playbook.json
+++ b/f/ansible-playbook.json
@@ -214,10 +214,6 @@
           "$ref": "#/$defs/templated-integer",
           "title": "Timeout"
         },
-        "user": {
-          "title": "Remote User",
-          "type": "string"
-        },
         "vars": {
           "title": "Vars",
           "type": "object"
@@ -757,10 +753,6 @@
           "$ref": "#/$defs/templated-integer",
           "title": "Timeout"
         },
-        "user": {
-          "title": "Remote User",
-          "type": "string"
-        },
         "vars": {
           "title": "Vars",
           "type": "object"
@@ -1016,10 +1008,6 @@
         "until": {
           "$ref": "#/$defs/complex_conditional",
           "title": "Until"
-        },
-        "user": {
-          "title": "Remote User",
-          "type": "string"
         },
         "vars": {
           "title": "Vars",

--- a/f/ansible-tasks.json
+++ b/f/ansible-tasks.json
@@ -166,10 +166,6 @@
           "$ref": "#/$defs/templated-integer",
           "title": "Timeout"
         },
-        "user": {
-          "title": "Remote User",
-          "type": "string"
-        },
         "vars": {
           "title": "Vars",
           "type": "object"
@@ -468,10 +464,6 @@
         "until": {
           "$ref": "#/$defs/complex_conditional",
           "title": "Until"
-        },
-        "user": {
-          "title": "Remote User",
-          "type": "string"
         },
         "vars": {
           "title": "Vars",

--- a/f/ansible.json
+++ b/f/ansible.json
@@ -205,10 +205,6 @@
           "$ref": "#/$defs/templated-integer",
           "title": "Timeout"
         },
-        "user": {
-          "title": "Remote User",
-          "type": "string"
-        },
         "vars": {
           "title": "Vars",
           "type": "object"
@@ -740,10 +736,6 @@
           "$ref": "#/$defs/templated-integer",
           "title": "Timeout"
         },
-        "user": {
-          "title": "Remote User",
-          "type": "string"
-        },
         "vars": {
           "title": "Vars",
           "type": "object"
@@ -992,10 +984,6 @@
         "until": {
           "$ref": "#/$defs/complex_conditional",
           "title": "Until"
-        },
-        "user": {
-          "title": "Remote User",
-          "type": "string"
         },
         "vars": {
           "title": "Vars",

--- a/test/playbooks/user_valid.yml
+++ b/test/playbooks/user_valid.yml
@@ -1,0 +1,3 @@
+- hosts: localhost
+  user: foo # <-- allowed, alias to remote_user
+  tasks: []


### PR DESCRIPTION
Fixes regression introduced by #370 which accidentally included `user` property for tasks and blocks.