### PR TITLE
Support for cgroupns parameter

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -13,6 +13,7 @@ ansiblelint
 bigcrypt
 bindep
 bsdi
+cgroupns
 cliconf
 cmds
 codespell

--- a/f/molecule.json
+++ b/f/molecule.json
@@ -117,6 +117,10 @@
           "title": "Box",
           "type": "string"
         },
+        "cgroupns": {
+          "title": "Cgroupns",
+          "type": "string"
+        },
         "children": {
           "items": {
             "type": "string"
@@ -204,10 +208,6 @@
         "pre_build_image": {
           "title": "Pre Build Image",
           "type": "boolean"
-        },
-        "cgroupns": {
-          "title": "Cgroupns",
-          "type": "string"
         },
         "privileged": {
           "title": "Privileged",

--- a/f/molecule.json
+++ b/f/molecule.json
@@ -205,6 +205,10 @@
           "title": "Pre Build Image",
           "type": "boolean"
         },
+        "cgroupns": {
+          "title": "Cgroupns",
+          "type": "string"
+        },
         "privileged": {
           "title": "Privileged",
           "type": "boolean"


### PR DESCRIPTION
So that containers can be spun up using the option `--cgroupns=host` to use `systemd` with `cgroup v2` system.