### PR TITLE
Update molecule schema for vagrant

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -13,11 +13,13 @@ ansiblelint
 bigcrypt
 bindep
 bsdi
+cachier
 cgroupns
 cliconf
 cmds
 codespell
 cpus
+cpuset
 dbservers
 deps
 devel

--- a/f/molecule.json
+++ b/f/molecule.json
@@ -45,6 +45,14 @@
     "MoleculeDriverModel": {
       "additionalProperties": false,
       "properties": {
+        "cachier": {
+          "title": "Cachier",
+          "type": "string"
+        },
+        "default_box": {
+          "title": "DefaultBox",
+          "type": "string"
+        },
         "name": {
           "enum": [
             "azure",
@@ -66,9 +74,17 @@
         "options": {
           "$ref": "#/$defs/MoleculeDriverOptionsModel"
         },
+        "parallel": {
+          "title": "Parallel",
+          "type": "boolean"
+        },
         "provider": {
           "title": "Provider",
           "type": "object"
+        },
+        "provision": {
+          "title": "Provision",
+          "type": "boolean"
         },
         "safe_files": {
           "items": {
@@ -162,11 +178,15 @@
         },
         "hostname": {
           "title": "Hostname",
-          "type": "string"
+          "type": ["string", "boolean"]
         },
         "image": {
           "title": "Image",
           "type": ["string", "null"]
+        },
+        "interfaces": {
+          "title": "Interfaces",
+          "type": "array"
         },
         "memory": {
           "title": "Memory",
@@ -212,6 +232,10 @@
         "privileged": {
           "title": "Privileged",
           "type": "boolean"
+        },
+        "provider_options": {
+          "title": "Provider options",
+          "type": "object"
         },
         "provider_raw_config_args": {
           "items": {

--- a/test/molecule/vagrant/molecule.yml
+++ b/test/molecule/vagrant/molecule.yml
@@ -1,0 +1,47 @@
+---
+dependency:
+  name: shell
+  enabled: false
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+  provision: false
+  cachier: machine
+  parallel: true
+  default_box: "generic/alpine310"
+platforms:
+  - name: instance
+    hostname: foo.bar.com
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: dhcp
+    instance_raw_config_args:
+      - 'vm.synced_folder ".", "/vagrant", type: "rsync"'
+      - 'vm.provision :shell, inline: "uname"'
+    config_options:
+      ssh.keep_alive: true
+      ssh.remote_user: "vagrant"
+      synced_folder: true
+    box: fedora/32-cloud-base
+    box_version: 32.20200422.0
+    box_url: "http://127.0.0.1/box.img"
+    memory: 512
+    cpus: 1
+    provider_options:
+      video_type: "vga"
+    provider_raw_config_args:
+      - cpuset = '1-4,^3,6'
+  - name: instance2
+    hostname: false
+
+provisioner:
+  name: ansible


### PR DESCRIPTION
Current schema doesn't support all options of molecule-vagrant, leading to failures.
This patch is updating the schema and provides a molecule.yml file with all options.

Note: This test file is not a real file. The idea is to check all options.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>