### PR TITLE
vars_files should accept array[array[string]]

### DIFF
--- a/f/ansible-playbook.json
+++ b/f/ansible-playbook.json
@@ -628,7 +628,17 @@
         },
         "vars_files": {
           "items": {
-            "type": "string"
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "title": "Vars Files",
           "type": [

--- a/f/ansible.json
+++ b/f/ansible.json
@@ -613,7 +613,17 @@
         },
         "vars_files": {
           "items": {
-            "type": "string"
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "title": "Vars Files",
           "type": ["array", "string", "null"]

--- a/negative_test/playbooks/var_files_list_list_number.yml
+++ b/negative_test/playbooks/var_files_list_list_number.yml
@@ -1,0 +1,5 @@
+---
+- name: var_files should not accept array[array[number]]
+  hosts: localhost
+  vars_files:
+    - [0]

--- a/negative_test/playbooks/var_files_list_list_number.yml.md
+++ b/negative_test/playbooks/var_files_list_list_number.yml.md
@@ -48,13 +48,13 @@
     "schemaPath": "#/patternProperties/vars/type"
   },
   {
-    "instancePath": "/0/vars_files/0",
+    "instancePath": "/0/vars_files/0/0",
     "keyword": "type",
-    "message": "must be array",
+    "message": "must be string",
     "params": {
-      "type": "array"
+      "type": "string"
     },
-    "schemaPath": "#/properties/vars_files/items/anyOf/0/type"
+    "schemaPath": "#/properties/vars_files/items/anyOf/0/items/type"
   },
   {
     "instancePath": "/0/vars_files/0",
@@ -93,9 +93,9 @@ stdout:
   "status": "fail",
   "errors": [
     {
-      "filename": "negative_test/playbooks/var_files_list_number.yml",
+      "filename": "negative_test/playbooks/var_files_list_list_number.yml",
       "path": "$[0]",
-      "message": "{'name': 'var_files should not accept array[number]', 'hosts': 'localhost', 'vars_files': [0]} is not valid under any of the given schemas",
+      "message": "{'name': 'var_files should not accept array[array[number]]', 'hosts': 'localhost', 'vars_files': [[0]]} is not valid under any of the given schemas",
       "has_sub_errors": true,
       "best_match": {
         "path": "$[0]",
@@ -108,7 +108,7 @@ stdout:
         },
         {
           "path": "$[0]",
-          "message": "{'name': 'var_files should not accept array[number]', 'hosts': 'localhost', 'vars_files': [0]} is not valid under any of the given schemas"
+          "message": "{'name': 'var_files should not accept array[array[number]]', 'hosts': 'localhost', 'vars_files': [[0]]} is not valid under any of the given schemas"
         },
         {
           "path": "$[0]",
@@ -120,19 +120,19 @@ stdout:
         },
         {
           "path": "$[0].vars_files",
-          "message": "[0] is not of type 'object'"
+          "message": "[[0]] is not of type 'object'"
         },
         {
           "path": "$[0].vars_files[0]",
-          "message": "0 is not valid under any of the given schemas"
+          "message": "[0] is not valid under any of the given schemas"
         },
         {
-          "path": "$[0].vars_files[0]",
-          "message": "0 is not of type 'array'"
-        },
-        {
-          "path": "$[0].vars_files[0]",
+          "path": "$[0].vars_files[0][0]",
           "message": "0 is not of type 'string'"
+        },
+        {
+          "path": "$[0].vars_files[0]",
+          "message": "[0] is not of type 'string'"
         }
       ]
     }

--- a/test/playbooks/var_files.yml
+++ b/test/playbooks/var_files.yml
@@ -11,3 +11,8 @@
   hosts: localhost
   vars_files:
     - /dev/null
+
+- name: var_files should accept array[array[string]]
+  hosts: localhost
+  vars_files:
+    - [/dev/null, /dev/null]


### PR DESCRIPTION
This change updates the playbook schema to accept this valid construct:

playbook.yml:
```yaml
---
- name: Test Ansible Lint schema error
  hosts: localhost
  vars_files:
    - ["vars/{{ ansible_distribution }}.yml", vars/default.yml]

  tasks:
    - name: Print foo
      ansible.builtin.debug:
        var: foo
```

vars/default.yml:
```yaml
---
foo: default
```